### PR TITLE
Prevent fatal error when TinyMCE is called in the frontend

### DIFF
--- a/mediacore.php
+++ b/mediacore.php
@@ -103,6 +103,9 @@ add_filter('tiny_mce_before_init','mcore_chooser_tinymce_settings');
  */
 function mcore_get_plugin_version() {
 	$version = 'mediacore-wordpress-chooser-';
+	if ( false === function_exists( 'get_plugin_data' ) ) {
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+	}
 	$plugin_data = get_plugin_data( __FILE__ );
 	if (array_key_exists('Version', $plugin_data)) {
 		$version .= $plugin_data['Version'];


### PR DESCRIPTION
`mcore_get_plugin_version()` calls `get_plugin_data()`, which is an admin-only function.

When a 3rd-party plugin calls TinyMCE on the frontend, this can cause a fatal error since Mediacore assumes it is in the admin area on the `'tiny_mce_before_init'` hook.

This commit loads up the WP plugin API file so Mediacore can access `get_plugin_data()` if it doesn't already exist.